### PR TITLE
support one-part FIDE names

### DIFF
--- a/app/models/fide_player.rb
+++ b/app/models/fide_player.rb
@@ -89,6 +89,7 @@ class FidePlayer < ApplicationRecord
   private
 
   def name_mismatches(p)
+    return 0 if ICU::Name.new(first_name, last_name).match(p.first_name, p.last_name)
     m = 0
     m+= 1 unless ICU::Name.new(first_name, "Smith").match(p.first_name, "Smith")
     m+= 1 unless ICU::Name.new("Johnny", last_name).match("Johnny", p.last_name)

--- a/spec/features/fide_players_spec.rb
+++ b/spec/features/fide_players_spec.rb
@@ -31,6 +31,15 @@ describe FidePlayer do
       expect(@f.icu_id).to be_nil
     end
 
+    it "should create a link if FIDE name is in one part" do
+      @f.update_column(:first_name, "")
+      @f.update_column(:last_name, "Mark Orr")
+      page.click_link @link
+      sleep @sleep
+      @f.reload
+      expect(@f.icu_id).to eq(@i.id)
+    end
+
     it "should not create a link if federation is mismatched" do
       @i.update_column(:fed, "SCO")
       page.click_link @link


### PR DESCRIPTION
If FIDE name is "David Murray" instead of "Murray, David" we should still support this format and match it with an ICU name of "Murray, David". Several federations do this for most of their players, most notably India.