### PR TITLE
lower rating floor to 400

### DIFF
--- a/app/models/rating_list.rb
+++ b/app/models/rating_list.rb
@@ -121,7 +121,7 @@ class RatingList < ApplicationRecord
         legacy += 1
       end
 
-      rating = 700 if rating && rating < 700
+      rating = 400 if rating && rating < 400
 
       current = @current[icu_id]
       case

--- a/app/views/icu_ratings/index.html.haml
+++ b/app/views/icu_ratings/index.html.haml
@@ -39,11 +39,12 @@
       Check the
       %em show ICU ID
       option or hover your mouse over the player's name.
-    %dt Why do so many players have a rating of 700 but none below that?
+    %dt Why do so many players have a rating of 400, or 700 on earlier lists but none below that?
     %dd
       In order not to discourage learners, the ICU has a policy of rounding up
-      published ratings below 700. The real ratings stored in the database are
-      unaffected by this policy.
+      published ratings below 400, when it comes to publication on the monthly lists. The ratings
+      used for calculation of opponents' rating changes, and for the "live" rating list, are
+      unaffected by this policy.  Before September 2023 this floor was set at 700 instead.
     %dt What are "original" ratings?
     %dd
       These are ratings as they were originally at the end of the month in

--- a/app/views/pages/my_home.html.haml
+++ b/app/views/pages/my_home.html.haml
@@ -64,6 +64,6 @@
       players with full ratings.
     %dt Why is my published rating 700 even though my actual rating is less than 700?
     %dd
-      The ICU have a long tradition of rounding up published ratings lower than 700
+      For the published rating lists, ratings below 400 are rounded up
       to avoid discouraging beginners.
     = render "more_help"


### PR DESCRIPTION
Reduce rating floor to 400 from 700.

Our intent to change this was discussed at an executive meeting during 2022 and communicated to the membership in the 2022 Rating Officer's Report. Rationale:

- players these days play online, and expect to see their rating fluctuate, even if they are beginners
-  players these days pay more attention to the live list, which has no rating floor. This brings the published lists closer in line with the live list.
- Over 1/4 of our active players had ratings of 700 or below, making the monthly lists effectively meaningless for such a large section of players.

Reducing it further is an option to consider, though going below 0 seems silly and we should prefer to reform the system.

