### PR TITLE
Once off rating adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ config/database.yml
 config/app_config.yml
 config/secrets.yml
 .idea/*
+.vscode/
 *.swp
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -199,6 +199,20 @@ class Player < ApplicationRecord
   end
 
   # returns hash of icu_id : Player
+  # Last rating for a player is normally his rating after the last rated
+  # tournament he played in.
+  # There are two other situations to consider:
+  # - a player has never played a tournament, but has a "legacy rating" from
+  #   the previous rating system. In this case his last rating is the legacy
+  #   rating.
+  # - a player has played no tournament since the 2024-04-01 rating adjustment.
+  #   In this case his last rating is his rating on the 2024-04 rating list.
+  #
+  # `max_rorder` is the rating order of the latest tournament to consider for
+  #  a player's rating, i.e. the last rated tournament he could have played in
+  #  before the date we are calculating ratings for.
+  # `max_date` is only used if `max_rorder` makes it ambiguous whether the last
+  # tournament was slightly before or slightly after the 2024-04-01 adjustment.
   def self.get_last_ratings(icu_ids, max_rorder: nil, max_date: nil)
     max_date ||= Date.new(2099, 12, 31)
     last_unadjusted = Tournament.where("finish < ? AND rorder IS NOT NULL", ICU::RatingAdjustment::date).ordered.first

--- a/app/models/rating_list.rb
+++ b/app/models/rating_list.rb
@@ -185,9 +185,9 @@ class RatingList < ApplicationRecord
       report_header "Change statistics"
       changes.keys.sort.each { |bucket| report_examples(changes[bucket], bucket) }
     end
-    
+
     if last_list?
-      t3 = Time.now      
+      t3 = Time.now
       report_header "Starting live rating recalculation at #{t1.to_s(:tbm)}"
       count = LiveRating.recalculate
       t4 = Time.now
@@ -241,7 +241,7 @@ class RatingList < ApplicationRecord
     report_header "Getting latest player ratings from tournaments"
     t1 = Time.now
     report_item "started at:  #{t1.to_s(:tbm)}"
-    ratings = Player.get_last_ratings(icu_ids, max_rorder=rorder - 1)
+    ratings = Player.get_last_ratings(icu_ids, max_rorder: rorder - 1, max_date: date)
     t2 = Time.now
     report_item "finished at: #{t2.to_s(:tbm)} (#{((t2 - t1) * 1000.0).round} ms)"
     report_item "matching subscriptions: #{ratings.size}"
@@ -258,7 +258,7 @@ class RatingList < ApplicationRecord
   end
 
   def get_icu_ids_for_list
-    return IcuPlayer.all.pluck(:id) if date == ICU::RatingAdjustment::ADJUSTMENT_DATE
+    return IcuPlayer.all.pluck(:id) if date == ICU::RatingAdjustment::date
     get_subscriptions.keys
   end
 

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -785,7 +785,7 @@ class Tournament < ApplicationRecord
   # Get the start ratings of all players.
   def get_old_ratings
     icu_ids = players.select{ |p| p.category == "icu_player" }.map(&:icu_id)
-    latest = Player.get_last_ratings(icu_ids, max_rorder=rorder - 1)
+    latest = Player.get_last_ratings(icu_ids, max_rorder: rorder - 1, max_date: finish)
     legacy = OldRating.get_ratings(icu_ids)
     players.each { |p| p.get_old_rating(latest, legacy) }
   end

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -785,7 +785,7 @@ class Tournament < ApplicationRecord
   # Get the start ratings of all players.
   def get_old_ratings
     icu_ids = players.select{ |p| p.category == "icu_player" }.map(&:icu_id)
-    latest = Player.get_last_ratings(icu_ids, rorder)
+    latest = Player.get_last_ratings(icu_ids, max_rorder=rorder - 1)
     legacy = OldRating.get_ratings(icu_ids)
     players.each { |p| p.get_old_rating(latest, legacy) }
   end

--- a/lib/icu/database.rb
+++ b/lib/icu/database.rb
@@ -283,7 +283,7 @@ module ICU
         # This will happen once and they'll be replaced with the same fees from the new database.
         def remove_legacy_fees
           @legacy_deletes = Fee.where(category: "FTR").where("id < 400").delete_all
-
+        end
 
         def get_our_fees
           @our_fees = Fee.all.inject({}) { |h,f| h[f.id] = f; h }

--- a/lib/icu/database.rb
+++ b/lib/icu/database.rb
@@ -283,7 +283,7 @@ module ICU
         # This will happen once and they'll be replaced with the same fees from the new database.
         def remove_legacy_fees
           @legacy_deletes = Fee.where(category: "FTR").where("id < 400").delete_all
-        end
+
 
         def get_our_fees
           @our_fees = Fee.all.inject({}) { |h,f| h[f.id] = f; h }

--- a/lib/icu/rating_adjustment.rb
+++ b/lib/icu/rating_adjustment.rb
@@ -2,19 +2,22 @@
 # Motivation and details at https://www.icu.ie/system/downloads/000/000/505/8b01f5bb45f5ef325c201a7017564b232f585fc9.pdf
 
 module ICU
-    class RatingAdjustment
-        ADJUSTMENT_DATE = "2024-04-01"
+  class RatingAdjustment
+    ADJUSTMENT_DATE = "2024-04-01"
 
-        def self.maybe_adjust(old, date)
-            return old if date != ::Date.parse(ADJUSTMENT_DATE)
-            self.adjust old
-        end
-
-        private
-        def self.adjust(old)
-            return old if old >= 2000
-            (old + 0.6 * (2000 - old)).to_i
-        end
+    def self.date
+      ::Date.parse(ADJUSTMENT_DATE)
     end
+
+    def self.maybe_adjust(old, date)
+      return old if date != ADJUSTMENT_DATE
+      self.adjust old
+    end
+
+    private
+    def self.adjust(old)
+      return old if old >= 2000
+      (old + 0.6 * (2000 - old)).to_i
+    end
+  end
 end
-        

--- a/lib/icu/rating_adjustment.rb
+++ b/lib/icu/rating_adjustment.rb
@@ -3,10 +3,10 @@
 
 module ICU
   class RatingAdjustment
-    ADJUSTMENT_DATE = "2024-04-01"
+    ADJUSTMENT_DATE = ::Date.new(2024, 4, 1)
 
     def self.date
-      ::Date.parse(ADJUSTMENT_DATE)
+      ADJUSTMENT_DATE
     end
 
     def self.maybe_adjust(old, date)

--- a/lib/icu/rating_adjustment.rb
+++ b/lib/icu/rating_adjustment.rb
@@ -16,6 +16,7 @@ module ICU
 
     private
     def self.adjust(old)
+      return nil if old.nil?
       return old if old >= 2000
       (old + 0.6 * (2000 - old)).to_i
     end

--- a/lib/icu/rating_adjustment.rb
+++ b/lib/icu/rating_adjustment.rb
@@ -1,0 +1,20 @@
+# A once-off adjustment to ICU ratings
+# Motivation and details at https://www.icu.ie/system/downloads/000/000/505/8b01f5bb45f5ef325c201a7017564b232f585fc9.pdf
+
+module ICU
+    class RatingAdjustment
+        ADJUSTMENT_DATE = "2024-04-01"
+
+        def self.maybe_adjust(old, date)
+            return old if date != ::Date.parse(ADJUSTMENT_DATE)
+            self.adjust old
+        end
+
+        private
+        def self.adjust(old)
+            return old if old >= 2000
+            (old + 0.6 * (2000 - old)).to_i
+        end
+    end
+end
+        

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -99,4 +99,59 @@ describe Player do
     end
 
   end
+
+  context "get_last_ratings" do
+    before(:each) do
+      @bunratty = Tournament.new(
+        original_name: "Bunratty",
+        name: "Bunratty",
+        start: "2024-03-08",
+        finish: "2024-03-10",
+        rorder: 1,
+        rounds: 6,
+        user_id: 100,
+        stage: "rated")
+      @bunratty.save!
+
+      @malahide = Tournament.new(
+        original_name: "Malahide",
+        name: "Malahide",
+        start: "2024-05-04",
+        finish: "2024-05-06",
+        rorder: 2,
+        rounds: 6,
+        user_id: 100,
+        stage: "rated")
+      @malahide.save!
+
+      @david = Player.new(
+        first_name:  "David",
+        last_name:   "Murray",
+        original_name: "Murray, David",
+        icu_id:      4941,
+        new_rating:  2100,
+        num: 5,
+        tournament_id: @bunratty.id
+      )
+      @david.save!
+      @david2 = @david.dup
+      @david2.tournament_id = @malahide.id
+      @david2.new_rating = 2080
+      @david2.save!
+
+    end
+
+    it "before the adjustment, should get a player's rating" do
+      players = Player.get_last_ratings([4941], max_rorder = 1)
+      expect(players[4941].new_rating).to eq(2100)
+    end
+
+    it "after the adjustment, should get a player's rating" do
+      players = Player.get_last_ratings([4941])
+      expect(players[4941].new_rating).to eq(2080)
+    end
+  end
+
+
+
 end

--- a/spec/models/rating_list_spec.rb
+++ b/spec/models/rating_list_spec.rb
@@ -64,6 +64,7 @@ describe RatingList do
       end
       @l1 = RatingList.find_by_date(Date.new(2012, 1, 1))
       @l2 = RatingList.find_by_date(Date.new(2012, 5, 1))
+      @l3 = RatingList.find_by_date(Date.new(2024, 4, 1)) # Adjusted ratings
     end
 
     it "should be setup OK" do
@@ -77,6 +78,8 @@ describe RatingList do
       expect(@l1.publications).to be_empty
       expect(@l2).to_not be_nil
       expect(@l2.publications).to be_empty
+      expect(@l3).to_not be_nil
+      expect(@l3.publications).to be_empty
     end
 
     it "should publish lists" do
@@ -274,6 +277,30 @@ describe RatingList do
       expect(rating.rating).to eq(player.new_rating)
       expect(rating.full).to eq(player.new_full)
       expect(rating.original_rating).to_not eq(player.new_rating)
+    end
+
+    it "should publish adjusted list for April 2024" do
+      pub_date = Date.new(2024, 4, 1)
+      pay_date = Date.new(2024, 4, 30)
+      msg = @l3.publish(pub_date)
+      expect(@l3.publications.size).to eq(1)
+      p = @l3.publications[0]
+
+      # Player who played in tournament 1 but didn't subscribe at all.
+      # Should still be published on April list
+      player = @t1.players.find_by_icu_id(5722)
+      expect(player).to_not be_nil
+      rating = IcuRating.find_by_list_and_icu_id(@l3.date, 5722)
+      expect(rating).to_not be_nil
+
+      # Player who played in tournament 1 with a rating < 2000 is adjusted
+      # Should have adjusted rating
+      player = @t1.players.find_by_icu_id(12664)
+      expect(player).to_not be_nil
+      rating = IcuRating.find_by_list_and_icu_id(@l3.date, 12664)
+      expect(rating).to_not be_nil
+      expect(rating.rating).to be > player.new_rating
+
     end
   end
 end

--- a/spec/other/rating_adjustment_spec.rb
+++ b/spec/other/rating_adjustment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe ICU::RatingAdjustment do
+  it "adjusts ratings on 2024-04-01" do
+    r = ICU::RatingAdjustment.maybe_adjust(1400, Date.parse("2024-04-01"))
+    expect(r).to eq 1760
+    r = ICU::RatingAdjustment.maybe_adjust(2100, Date.parse("2024-04-01"))
+    expect(r).to eq 2100
+  end
+
+  it "does not adjust ratings on 2024-03-01" do
+    r = ICU::RatingAdjustment.maybe_adjust(1400, Date.parse("2024-03-01"))
+    expect(r).to eq 1400
+    r = ICU::RatingAdjustment.maybe_adjust(2100, Date.parse("2024-03-01"))
+    expect(r).to eq 2100
+  end
+end

--- a/spec/other/rating_adjustment_spec.rb
+++ b/spec/other/rating_adjustment_spec.rb
@@ -2,16 +2,16 @@ require 'rails_helper'
 
 describe ICU::RatingAdjustment do
   it "adjusts ratings on 2024-04-01" do
-    r = ICU::RatingAdjustment.maybe_adjust(1400, Date.parse("2024-04-01"))
+    r = ICU::RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 4, 1))
     expect(r).to eq 1760
-    r = ICU::RatingAdjustment.maybe_adjust(2100, Date.parse("2024-04-01"))
+    r = ICU::RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 4, 1))
     expect(r).to eq 2100
   end
 
   it "does not adjust ratings on 2024-03-01" do
-    r = ICU::RatingAdjustment.maybe_adjust(1400, Date.parse("2024-03-01"))
+    r = ICU::RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 3, 1))
     expect(r).to eq 1400
-    r = ICU::RatingAdjustment.maybe_adjust(2100, Date.parse("2024-03-01"))
+    r = ICU::RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 3, 1))
     expect(r).to eq 2100
   end
 end

--- a/spec/other/rating_adjustment_spec.rb
+++ b/spec/other/rating_adjustment_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe ICU::RatingAdjustment do
   it "adjusts ratings on 2024-04-01" do
+    r = ICU::RatingAdjustment.maybe_adjust(nil, ::Date.new(2024, 4, 1))
+    expect(r).to be nil
     r = ICU::RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 4, 1))
     expect(r).to eq 1760
     r = ICU::RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 4, 1))
@@ -9,6 +11,8 @@ describe ICU::RatingAdjustment do
   end
 
   it "does not adjust ratings on 2024-03-01" do
+    r = ICU::RatingAdjustment.maybe_adjust(nil, ::Date.new(2024, 3, 1))
+    expect(r).to be nil
     r = ICU::RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 3, 1))
     expect(r).to eq 1400
     r = ICU::RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 3, 1))


### PR DESCRIPTION
Implements a one-time adjustment in ratings as specified in https://www.icu.ie/system/downloads/000/000/505/8b01f5bb45f5ef325c201a7017564b232f585fc9.pdf.

There are three parts to this:

1. The adjustment. This logic is very short and is in `rating_adjustment.rb`. A rating under 2000 is adjusted upwards by 0.6 of the difference between the rating and 2000.

2. Additional logic to publish all ratings on the April 2024 rating list, not just subscribed members. This logic is in `rating_list.rb`. The reason for this is made clear in part 3.

3. The calculation of "last rating". This is used:
   - for determining the initial rating at the start of a tournament
   - for determining a player's live rating
   - for determining a player's rating on a published rating list.

This calculation takes as a player's "last rating" his rating at the end of the last rated tournament in which he participated.

This logic is now amended so that it takes his rating on the April 2024 rating list, if the current date is after April 1 2024 and he has played no tournament since April 1 2024. This logic is in `player.rb`.
