### PR TITLE
only include tournaments strictly before publication date

### DIFF
--- a/app/models/rating_list.rb
+++ b/app/models/rating_list.rb
@@ -281,8 +281,8 @@ class RatingList < ApplicationRecord
   end
 
   def get_last_tournament
-    report_header "Last tournament to finish on or before #{tournament_cut_off}"
-    tournament = Tournament.get_last_rated(tournament_cut_off)
+    report_header "Last tournament to finish before #{tournament_cut_off}"
+    tournament = Tournament.get_last_rated(tournament_cut_off - 1.days)
     raise "no last tournament found" unless tournament
     report_item "name: #{tournament.name}"
     report_item "finish date: #{tournament.finish}"


### PR DESCRIPTION
Fixes an off-by-one error introduced in #15.

We now look at dates strictly before the publication date, when deciding what tournaments to include in a rating list.

This makes sense with our current approach where the rating list is published near the start of the month: the April rating list can include only events through March 31 inclusive.