### PR TITLE
Change adjustment date to march

### DIFF
--- a/app/lib/rating_adjustment.rb
+++ b/app/lib/rating_adjustment.rb
@@ -2,7 +2,7 @@
 # Motivation and details at https://www.icu.ie/system/downloads/000/000/505/8b01f5bb45f5ef325c201a7017564b232f585fc9.pdf
 
 module RatingAdjustment
-  ADJUSTMENT_DATE = ::Date.new(2024, 4, 1)
+  ADJUSTMENT_DATE = ::Date.new(2024, 3, 1)
 
   def self.date
     ADJUSTMENT_DATE

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -205,14 +205,14 @@ class Player < ApplicationRecord
   # - a player has never played a tournament, but has a "legacy rating" from
   #   the previous rating system. In this case his last rating is the legacy
   #   rating.
-  # - a player has played no tournament since the 2024-04-01 rating adjustment.
-  #   In this case his last rating is his rating on the 2024-04 rating list.
+  # - a player has played no tournament since the 2024-03-01 rating adjustment.
+  #   In this case his last rating is his rating on the 2024-03 rating list.
   #
   # `max_rorder` is the rating order of the latest tournament to consider for
   #  a player's rating, i.e. the last rated tournament he could have played in
   #  before the date we are calculating ratings for.
   # `max_date` is only used if `max_rorder` makes it ambiguous whether the last
-  # tournament was slightly before or slightly after the 2024-04-01 adjustment.
+  # tournament was slightly before or slightly after the 2024-03-01 adjustment.
   def self.get_last_ratings(icu_ids, max_rorder: nil, max_date: nil)
     max_date ||= Date.new(2099, 12, 31)
     last_unadjusted = Tournament.where("finish < ? AND rorder IS NOT NULL", RatingAdjustment::date).ordered.first

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -120,8 +120,8 @@ describe Player do
       @bunratty = Tournament.new(
         original_name: "Bunratty",
         name: "Bunratty",
-        start: "2024-03-08",
-        finish: "2024-03-10",
+        start: "2024-02-08",
+        finish: "2024-02-10",
         rorder: 1,
         rounds: 6,
         user_id: 100,
@@ -166,13 +166,13 @@ describe Player do
       @john_bunratty.save!
 
       @david_rating = IcuRating.new(
-        list: Date.new(2024, 4, 1),
+        list: Date.new(2024, 3, 1),
         icu_id: @david.id,
         rating: 2100 # post-adjustment, though 2100 means no adjustment
       )
 
       @john_rating = IcuRating.new(
-        list: Date.new(2024, 4, 1),
+        list: Date.new(2024, 3, 1),
         icu_id: @john.id,
         rating: 1760 # post-adjustment rating
       )
@@ -180,7 +180,7 @@ describe Player do
     end
 
     it "before the adjustment, should get a player's rating" do
-      players = Player.get_last_ratings([795, 4941], max_rorder: 1, max_date: Date.new(2024, 3, 30))
+      players = Player.get_last_ratings([795, 4941], max_rorder: 1, max_date: Date.new(2024, 2, 29))
       expect(players[4941].new_rating).to eq(2100)
       expect(players[795].new_rating).to eq(1400)
     end

--- a/spec/models/rating_list_spec.rb
+++ b/spec/models/rating_list_spec.rb
@@ -64,7 +64,7 @@ describe RatingList do
       end
       @l1 = RatingList.find_by_date(Date.new(2012, 1, 1))
       @l2 = RatingList.find_by_date(Date.new(2012, 5, 1))
-      @l3 = RatingList.find_by_date(Date.new(2024, 4, 1)) # Adjusted ratings
+      @l3 = RatingList.find_by_date(Date.new(2024, 3, 1)) # Adjusted ratings
     end
 
     it "should be setup OK" do
@@ -279,15 +279,15 @@ describe RatingList do
       expect(rating.original_rating).to_not eq(player.new_rating)
     end
 
-    it "should publish adjusted list for April 2024" do
-      pub_date = Date.new(2024, 4, 1)
-      pay_date = Date.new(2024, 4, 30)
+    it "should publish adjusted list for March 2024" do
+      pub_date = Date.new(2024, 3, 1)
+      pay_date = Date.new(2024, 3, 30)
       msg = @l3.publish(pub_date)
       expect(@l3.publications.size).to eq(1)
       p = @l3.publications[0]
 
       # Player who played in tournament 1 but didn't subscribe at all.
-      # Should still be published on April list
+      # Should still be published on March list
       player = @t1.players.find_by_icu_id(5722)
       expect(player).to_not be_nil
       rating = IcuRating.find_by_list_and_icu_id(@l3.date, 5722)

--- a/spec/other/rating_adjustment_spec.rb
+++ b/spec/other/rating_adjustment_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 
 describe RatingAdjustment do
-  it "adjusts ratings on 2024-04-01" do
-    r = RatingAdjustment.maybe_adjust(nil, ::Date.new(2024, 4, 1))
-    expect(r).to be nil
-    r = RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 4, 1))
-    expect(r).to eq 1760
-    r = RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 4, 1))
-    expect(r).to eq 2100
-  end
-
-  it "does not adjust ratings on 2024-03-01" do
+  it "adjusts ratings on 2024-03-01" do
     r = RatingAdjustment.maybe_adjust(nil, ::Date.new(2024, 3, 1))
     expect(r).to be nil
     r = RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 3, 1))
-    expect(r).to eq 1400
+    expect(r).to eq 1760
     r = RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 3, 1))
+    expect(r).to eq 2100
+  end
+
+  it "does not adjust ratings on 2024-04-01" do
+    r = RatingAdjustment.maybe_adjust(nil, ::Date.new(2024, 4, 1))
+    expect(r).to be nil
+    r = RatingAdjustment.maybe_adjust(1400, ::Date.new(2024, 4, 1))
+    expect(r).to eq 1400
+    r = RatingAdjustment.maybe_adjust(2100, ::Date.new(2024, 4, 1))
     expect(r).to eq 2100
   end
 end


### PR DESCRIPTION
The FIDE adjustment in ratings was actually on March 1, not April 1.

This changes the ICU adjustment to be effective as of the same date.