### PR TITLE
Rating history graphs

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,6 +17,7 @@ class Ability
     can :juniors, IcuRating
     can :seniors, IcuRating
     can :improvers, IcuRating
+    can :show, IcuRating
     can :graph, IcuPlayer
     can :show, IcuPlayer, id: user.icu_id
     can :show, Player


### PR DESCRIPTION
On hiding the ratings lists behind a login wall in 1c6cf59, there was a line missing from `ability.rb` to allow members to access the JS endpoint which generates the rating history graphs.

Resolves #3.