### PR TITLE
42 Update fide downloads regex to allow https urls

### DIFF
--- a/app/views/admin/players/show.html.haml
+++ b/app/views/admin/players/show.html.haml
@@ -2,7 +2,7 @@
   = render partial: "admin/results/update_rateable", formats: :js
 
 %div.header
-  %span= @player.name(false)
+  %span{id: "player_name"}= @player.name(false)
 
 %table{class: "cushioned"}
   %tr

--- a/lib/fide/download.rb
+++ b/lib/fide/download.rb
@@ -321,6 +321,7 @@ module FIDE
     def request(url)
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.scheme == "https"
       http.read_timeout = 180
       req = Net::HTTP::Get.new(uri.request_uri)
       begin
@@ -333,11 +334,11 @@ module FIDE
     end
 
     def get_download_details
-      res = request("http://ratings.fide.com/download_lists.phtml")
+      res = request("https://ratings.fide.com/download_lists.phtml")
       # Example HTML that must be parsed
-      # <a href="http://ratings.fide.com/download/standard_rating_list_xml.zip" class="tur">XML format</a>
-      # <small>(06 Sep 2025, Sz: 12.42 MB)</small>
-      raise SyncError.new("no links detected") unless res.body.match(/href=["']?(http:\/\/ratings.fide.com\/download\/standard_rating_list_xml.zip)[^>]*>[^<]+<\/a>[^<]*<small>([^<,]+, [^<]+)<\/small>/)
+      # <a href=https://ratings.fide.com/download/standard_rating_list_xml.zip class=tur>XML format</a>
+      # <small>(23 Apr 2026, Sz: 13.17 MB)</small>
+      raise SyncError.new("no links detected") unless res.body.match(/href=["']?(https?:\/\/ratings\.fide\.com\/download\/standard_rating_list_xml\.zip)[^>]*>[^<]+<\/a>[^<]*<small>([^<,]+, [^<]+)<\/small>/)
       @link = $1
       note = $2
       @file = "standard_rating_list.xml"

--- a/spec/features/tournaments_spec.rb
+++ b/spec/features/tournaments_spec.rb
@@ -196,7 +196,7 @@ describe "Tournament" do
       t = Tournament.first
       tpath = "/admin/tournaments/#{t.id}"
       visit tpath
-      expect(page).to have_selector("div span", text: "Bunratty 2011")
+      expect(page).to have_selector("span#tournament_name", text: "Bunratty 2011")
       expect(page).to have_selector(:xpath, "//a[@href='#{tpath}/edit' and @data-remote='true']")
       expect(page).to have_selector(:xpath, "//a[@href='#{tpath}/edit?tie_breaks=' and @data-remote='true']")
       expect(page).to have_selector(:xpath, "//a[@href='#{tpath}/edit?ranks=' and @data-remote='true']")
@@ -205,17 +205,17 @@ describe "Tournament" do
       p = Player.find_by_last_name_and_first_name("Baburin", "Alexander")
       ppath = "/admin/players/#{p.id}"
       visit ppath
-      expect(page).to have_selector("div span", text: /Alexander Baburin/)
+      expect(page).to have_selector("span#player_name", text: /Alexander Baburin/)
       expect(page).to have_selector(:xpath, "//a[@href='#{ppath}/edit' and @data-remote='true']")
       expect(page).to have_selector(:xpath, "//a[starts-with(@href,'/icu_players') and @data-remote='true']")
       expect(page).to have_selector(:xpath, "//a[starts-with(@href,'/fide_players') and @data-remote='true']")
       expect(page).to have_selector(:xpath, "//a[starts-with(@href,'/admin/results') and @data-remote='true']", count: 6)
       login("reporter")
       visit tpath
-      expect(page).to have_selector("div span", text: "Bunratty 2011")
+      expect(page).to have_selector("span#tournament_name", text: "Bunratty 2011")
       expect(page).to have_no_selector(:xpath, "//a[starts-with(@href,'#{tpath}/edit')]")
       visit ppath
-      expect(page).to have_selector("div span", text: /Alexander Baburin/)
+      expect(page).to have_selector("span#player_name", text: /Alexander Baburin/)
       expect(page).to have_no_selector(:xpath, "//a[starts-with(@href,'#{ppath}/edit')]")
       expect(page).to have_no_selector(:xpath, "//a[starts-with(@href,'/icu_players') and @data-remote='true']")
       expect(page).to have_no_selector(:xpath, "//a[starts-with(@href,'/fide_players') and @data-remote='true']")
@@ -283,7 +283,7 @@ describe "Tournament" do
       t = Tournament.first
       tpath = "/admin/tournaments/#{t.id}"
       visit tpath
-      expect(page).to have_selector("div span", text: "U-19 All Ireland 2010")
+      expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland 2010")
       expect(page).to have_selector(:xpath, "//th[.='Status']/following-sibling::td[.='OK']")
       expect(t.players.count).to eq(8)
       expect(signature(t)).to eq("1|Cafolla|7||2|Dunne|4||3|Flynn|2||4|Fox|8||5|Griffiths|1||6|Hulleman|3||7|Orr|5||8|Sulskis|6")
@@ -292,10 +292,10 @@ describe "Tournament" do
 
       p = t.players.where(last_name: "Cafolla").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Cafolla")
+      expect(page).to have_selector("span#player_name", text: "Cafolla")
       page.click_link "Delete Player"
       page.driver.browser.switch_to.alert.accept
-      expect(page).to have_selector("div span", text: "U-19 All Ireland 2010")
+      expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland 2010")
       expect(page).to have_selector("div.flash span.notice", text: "Deleted player Cafolla, Peter")
       expect(page).to have_no_link("Cafolla, Peter")
       expect(signature(t)).to eq("1|Dunne|4||2|Flynn|2||3|Fox|7||4|Griffiths|1||5|Hulleman|3||6|Orr|5||7|Sulskis|6")
@@ -304,15 +304,15 @@ describe "Tournament" do
 
       p = t.players.where(last_name: "Flynn").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Flynn")
+      expect(page).to have_selector("span#player_name", text: "Flynn")
       expect(page).to have_no_link "Delete Player"
 
       p = t.players.where(last_name: "Fox").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Fox")
+      expect(page).to have_selector("span#player_name", text: "Fox")
       page.click_link "Delete Player"
       page.driver.browser.switch_to.alert.accept
-      expect(page).to have_selector("div span", text: "U-19 All Ireland 2010")
+      expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland 2010")
       expect(page).to have_selector("div.flash span.notice", text: "Deleted player Fox, Anthony")
       expect(page).to have_no_link("Fox, Anthony")
       expect(signature(t)).to eq("1|Dunne|4||2|Flynn|2||3|Griffiths|1||4|Hulleman|3||5|Orr|5||6|Sulskis|6")
@@ -321,25 +321,25 @@ describe "Tournament" do
 
       p = t.players.where(last_name: "Griffiths").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Griffiths")
+      expect(page).to have_selector("span#player_name", text: "Griffiths")
       expect(page).to have_no_link "Delete Player"
 
       p = t.players.where(last_name: "Hulleman").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Hulleman")
+      expect(page).to have_selector("span#player_name", text: "Hulleman")
       expect(page).to have_no_link "Delete Player"
 
       p = t.players.where(last_name: "Orr").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Orr")
+      expect(page).to have_selector("span#player_name", text: "Orr")
       expect(page).to have_no_link "Delete Player"
 
       p = t.players.where(last_name: "Sulskis").first
       visit "/admin/players/#{p.id}"
-      expect(page).to have_selector("div span", text: "Sulskis")
+      expect(page).to have_selector("span#player_name", text: "Sulskis")
       page.click_link "Delete Player"
       page.driver.browser.switch_to.alert.accept
-      expect(page).to have_selector("div span", text: "U-19 All Ireland 2010")
+      expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland 2010")
       expect(page).to have_selector("div.flash span.notice", text: "Deleted player Sulskis, Sarunas")
       expect(page).to have_no_link("Sulskis, Sarunas")
       expect(signature(t)).to eq("1|Dunne|4||2|Flynn|2||3|Griffiths|1||4|Hulleman|3||5|Orr|5")

--- a/spec/features/uploads_spec.rb
+++ b/spec/features/uploads_spec.rb
@@ -101,7 +101,7 @@ describe "Upload" do
         page.attach_file "file", test_file_path("junior_championships_u19_2010.zip")
         page.click_button "Upload"
 
-        expect(page).to have_selector("div span", text: "U-19 All Ireland")
+        expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland")
 
         expect(Upload.count).to eq(1)
         expect(Tournament.count).to eq(1)
@@ -137,7 +137,7 @@ describe "Upload" do
         page.attach_file "File to upload", test_file_path("junior_championships_u19_2010.txt")
         page.click_button "Upload"
 
-        expect(page).to have_selector("div span", text: "U-19 All Ireland")
+        expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland")
 
         expect(Upload.count).to eq(1)
         expect(Tournament.count).to eq(1)
@@ -174,7 +174,7 @@ describe "Upload" do
         page.attach_file "file", test_file_path("junior_championships_u19_2010.tab")
         page.click_button "Upload"
 
-        expect(page).to have_selector("div span", text: "U-19 All Ireland")
+        expect(page).to have_selector("span#tournament_name", text: "U-19 All Ireland")
 
         expect(Upload.count).to eq(1)
         expect(Tournament.count).to eq(1)
@@ -219,7 +219,7 @@ describe "Upload" do
         page.attach_file "file", test_file_path("isle_of_man_2007.csv")
         page.click_button "Upload"
 
-        expect(page).to have_selector("div span", text: "Isle of Man Masters, 2007")
+        expect(page).to have_selector("span#tournament_name", text: "Isle of Man Masters, 2007")
 
         tournament = Tournament.last
         expect(tournament.name).to eq("Isle of Man Masters, 2007")
@@ -271,7 +271,7 @@ describe "Upload" do
         page.attach_file "file", test_file_path("galway_major_2011.tab")
         page.click_button "Upload"
 
-        expect(page).to have_selector("div span", text: "Galway Major 2011")
+        expect(page).to have_selector("span#tournament_name", text: "Galway Major 2011")
         expect(page).to have_no_selector("span.alert")
 
         expect(Upload.count).to eq(2)
@@ -291,7 +291,7 @@ describe "Upload" do
         page.attach_file "file", test_file_path("rathmines_senior_2011.zip")
         page.click_button "Upload"
 
-        expect(page).to have_selector("div span", text: "Rathmines Senior 2011")
+        expect(page).to have_selector("span#tournament_name", text: "Rathmines Senior 2011")
 
         expect(Upload.count).to eq(1)
         expect(Tournament.count).to eq(1)

--- a/spec/models/old_rating_spec.rb
+++ b/spec/models/old_rating_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe OldRating do
   it "factory" do
     old = FactoryBot.create(:old_rating, icu_id: 1350)
-    expect(old.id).to eq(1)
     expect(old.icu_id).to eq(1350)
     expect(old.rating).to be <= 2400
     expect(old.games).to be <= 500

--- a/spec/models/old_rating_spec.rb
+++ b/spec/models/old_rating_spec.rb
@@ -8,7 +8,6 @@ describe OldRating do
     expect(old.games).to be <= 500
     expect(old.full).to be true
     old = FactoryBot.create(:old_rating, icu_id: 159, rating: 2198, games: 329, full: false)
-    expect(old.id).to eq(2)
     expect(old.icu_id).to eq(159)
     expect(old.rating).to eq(2198)
     expect(old.games).to eq(329)

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -46,7 +46,7 @@ describe Player do
     end
   end
 
-  context "#signature" do
+  context "#signature", truncation: true do
     before(:each) do
       f = "bunratty_masters_2011.tab"
       load_icu_players_for(f)

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -82,7 +82,7 @@ describe Tournament do
     end
   end
 
-  context "#rate!" do
+  context "#rate!", truncation: true do
     it "should rate tournaments" do
       # Setup two tournaments to begin with.
       @p = load_icu_players

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
     if example.metadata[:js]
       DatabaseCleaner.strategy = :truncation
     elsif example.metadata[:truncation]
+      DatabaseCleaner.clean_with(:truncation)
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 # Be patient with Ajax wait times.
 Capybara.configure do |config|
-  config.default_max_wait_time = 15
+  config.default_max_wait_time = 5
 end
 
 Capybara.server = :webrick
@@ -27,22 +27,30 @@ end
 User.pulls_disabled = true
 
 RSpec.configure do |config|
-  # Shorthand FG syntax.
-  # config.include FactoryBot::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
-  # To be able to use selenium tests we use database_cleaner with truncation
-  # strategy for all tests (slower but more reliable). See Railscasts 257.
+  # Disable Rspecs transactional fixtures by default
   config.use_transactional_fixtures = false
-  unless config.use_transactional_fixtures
-    config.before(:suite) do
-      DatabaseCleaner.strategy = :truncation
-    end
-    config.after(:each) do
-      DatabaseCleaner.clean
-    end
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
   end
 
-  # Deduce from location what spec types are (for example, which ones need capybara).
+  config.before(:each) do |example|
+    # Use truncation only for capybara/selenium tests
+    if example.metadata[:js]
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
+    end
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+    ActiveRecord::Base.clear_active_connections!
+  end
+
   config.infer_spec_type_from_file_location!
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,8 @@ RSpec.configure do |config|
     # Use truncation only for capybara/selenium tests
     if example.metadata[:js]
       DatabaseCleaner.strategy = :truncation
+    elsif example.metadata[:truncation]
+      DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction
     end


### PR DESCRIPTION
Resolves #42 

Updated the regex to allow http or https as FIDE now forces ssl for the download urls.