### PR TITLE
Download rapid and blitz FIDE ratings

### DIFF
--- a/app/views/fide_players/_search_results.html.haml
+++ b/app/views/fide_players/_search_results.html.haml
@@ -7,7 +7,9 @@
     %th YOB
     %th G
     %th Fed
-    %th Rating
+    %th Standard Rating
+    %th Rapid Rating
+    %th Blitz Rating
     %th Title
     %th ICU ID
   - if @fide_players.count == 0
@@ -28,6 +30,8 @@
         %td{class: "centered"}= p.gender
         %td{class: "centered"}= p.fed
         %td{class: "centered"}= p.rating
+        %td{class: "centered"}= p.rapid_rating
+        %td{class: "centered"}= p.blitz_rating
         %td{class: "centered"}= p.title
         %td{class: "centered", id: "icu_id_link_#{p.id}"}= render "icu_id_link", p: p
     - if @fide_players.multi_page

--- a/db/migrate/20260503162110_add_rapid_and_blitz_ratings_to_fide_players.rb
+++ b/db/migrate/20260503162110_add_rapid_and_blitz_ratings_to_fide_players.rb
@@ -1,0 +1,6 @@
+class AddRapidAndBlitzRatingsToFidePlayers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fide_players, :rapid_rating, :integer
+    add_column :fide_players, :blitz_rating, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,372 +2,374 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210611204425) do
+ActiveRecord::Schema.define(version: 2026_05_03_162110) do
 
-  create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "headline"
-    t.text     "story",      limit: 65535
-    t.integer  "user_id"
+  create_table "articles", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "headline"
+    t.text "story"
+    t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "published",                default: false
-    t.string   "identity"
-    t.index ["published"], name: "index_articles_on_published", using: :btree
-    t.index ["user_id"], name: "index_articles_on_user_id", using: :btree
+    t.boolean "published", default: false
+    t.string "identity"
+    t.index ["published"], name: "index_articles_on_published"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
-  create_table "downloads", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "comment"
-    t.string   "file_name"
-    t.string   "content_type"
-    t.binary   "data",           limit: 16777215
+  create_table "downloads", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "comment"
+    t.string "file_name"
+    t.string "content_type"
+    t.binary "data", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "rating_list_id"
+    t.integer "rating_list_id"
   end
 
-  create_table "events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.integer  "time",       limit: 2
-    t.text     "report",     limit: 65535
-    t.boolean  "success"
+  create_table "events", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.integer "time", limit: 2
+    t.text "report"
+    t.boolean "success"
     t.datetime "created_at"
   end
 
-  create_table "failures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.text     "details",    limit: 65535
+  create_table "failures", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.text "details"
     t.datetime "created_at"
   end
 
-  create_table "fees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "description"
-    t.string   "status",      limit: 25
-    t.string   "category",    limit: 3
-    t.date     "date"
-    t.integer  "icu_id"
-    t.boolean  "used",                   default: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-  end
-
-  create_table "fide_player_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.text     "description",      limit: 65535
-    t.integer  "players_in_file",  limit: 2,     default: 0
-    t.integer  "new_fide_records", limit: 1,     default: 0
-    t.integer  "new_icu_mappings", limit: 1,     default: 0
-    t.integer  "user_id"
-    t.datetime "created_at"
-  end
-
-  create_table "fide_players", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "last_name"
-    t.string   "first_name"
-    t.string   "fed",        limit: 3
-    t.string   "title",      limit: 3
-    t.string   "gender",     limit: 1
-    t.integer  "born",       limit: 2
-    t.integer  "rating",     limit: 2
-    t.integer  "icu_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["icu_id"], name: "index_fide_players_on_icu_id", using: :btree
-    t.index ["last_name", "first_name"], name: "index_fide_players_on_last_name_and_first_name", using: :btree
-  end
-
-  create_table "fide_ratings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "fide_id"
-    t.integer  "rating",     limit: 2
-    t.integer  "games",      limit: 2
-    t.date     "list"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["fide_id"], name: "index_fide_ratings_on_fide_id", using: :btree
-    t.index ["list"], name: "index_fide_ratings_on_list", using: :btree
-  end
-
-  create_table "icu_players", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "email"
-    t.string   "club"
-    t.string   "address"
-    t.string   "phone_numbers"
-    t.string   "fed",           limit: 3
-    t.string   "title",         limit: 3
-    t.string   "gender",        limit: 1
-    t.text     "note",          limit: 65535
-    t.date     "dob"
-    t.date     "joined"
-    t.boolean  "deceased"
-    t.integer  "master_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["last_name", "first_name"], name: "index_icu_players_on_last_name_and_first_name", using: :btree
-  end
-
-  create_table "icu_ratings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.date    "list"
+  create_table "fees", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "description"
+    t.string "status", limit: 25
+    t.string "category", limit: 3
+    t.date "date"
     t.integer "icu_id"
-    t.integer "rating",          limit: 2
-    t.boolean "full",                      default: false
-    t.integer "original_rating", limit: 2
-    t.boolean "original_full"
-    t.index ["icu_id"], name: "index_icu_ratings_on_icu_id", using: :btree
-    t.index ["list", "icu_id"], name: "index_icu_ratings_on_list_and_icu_id", unique: true, using: :btree
-    t.index ["list"], name: "index_icu_ratings_on_list", using: :btree
+    t.boolean "used", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "live_ratings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.integer "icu_id"
-    t.integer "rating",      limit: 2
-    t.integer "games",       limit: 2
-    t.boolean "full",                  default: false
-    t.integer "last_rating", limit: 2
-    t.boolean "last_full",             default: false
-    t.index ["icu_id"], name: "index_live_ratings_on_icu_id", unique: true, using: :btree
-  end
-
-  create_table "logins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "user_id"
-    t.string   "ip",         limit: 39
-    t.string   "problem",    limit: 8,  default: "none"
-    t.string   "role",       limit: 20
+  create_table "fide_player_files", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.text "description"
+    t.integer "players_in_file", limit: 2, default: 0
+    t.integer "new_fide_records", limit: 1, default: 0
+    t.integer "new_icu_mappings", limit: 1, default: 0
+    t.integer "user_id"
     t.datetime "created_at"
   end
 
-  create_table "old_rating_histories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer "old_tournament_id"
-    t.integer "icu_player_id"
-    t.integer "old_rating",         limit: 2
-    t.integer "new_rating",         limit: 2
-    t.integer "performance_rating", limit: 2
-    t.integer "tournament_rating",  limit: 2
-    t.integer "bonus",              limit: 2
-    t.integer "games",              limit: 1
-    t.integer "kfactor",            limit: 1
-    t.decimal "actual_score",                 precision: 3, scale: 1
-    t.decimal "expected_score",               precision: 8, scale: 6
-    t.index ["icu_player_id"], name: "index_old_rating_histories_on_icu_player_id", using: :btree
-    t.index ["old_tournament_id", "icu_player_id"], name: "by_icu_player_old_tournament", unique: true, using: :btree
-    t.index ["old_tournament_id"], name: "index_old_rating_histories_on_old_tournament_id", using: :btree
+  create_table "fide_players", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "last_name"
+    t.string "first_name"
+    t.string "fed", limit: 3
+    t.string "title", limit: 3
+    t.string "gender", limit: 1
+    t.integer "born", limit: 2
+    t.integer "rating", limit: 2
+    t.integer "icu_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "rapid_rating"
+    t.integer "blitz_rating"
+    t.index ["icu_id"], name: "index_fide_players_on_icu_id"
+    t.index ["last_name", "first_name"], name: "index_fide_players_on_last_name_and_first_name"
   end
 
-  create_table "old_ratings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "fide_ratings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "fide_id"
+    t.integer "rating", limit: 2
+    t.integer "games", limit: 2
+    t.date "list"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["fide_id"], name: "index_fide_ratings_on_fide_id"
+    t.index ["list"], name: "index_fide_ratings_on_list"
+  end
+
+  create_table "icu_players", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "club"
+    t.string "address"
+    t.string "phone_numbers"
+    t.string "fed", limit: 3
+    t.string "title", limit: 3
+    t.string "gender", limit: 1
+    t.text "note"
+    t.date "dob"
+    t.date "joined"
+    t.boolean "deceased"
+    t.integer "master_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["last_name", "first_name"], name: "index_icu_players_on_last_name_and_first_name"
+  end
+
+  create_table "icu_ratings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.date "list"
     t.integer "icu_id"
     t.integer "rating", limit: 2
-    t.integer "games",  limit: 2
-    t.boolean "full",             default: false
-    t.index ["icu_id"], name: "index_old_ratings_on_icu_id", unique: true, using: :btree
+    t.boolean "full", default: false
+    t.integer "original_rating", limit: 2
+    t.boolean "original_full"
+    t.index ["icu_id"], name: "index_icu_ratings_on_icu_id"
+    t.index ["list", "icu_id"], name: "index_icu_ratings_on_list_and_icu_id", unique: true
+    t.index ["list"], name: "index_icu_ratings_on_list"
   end
 
-  create_table "old_tournaments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string  "name"
-    t.date    "date"
+  create_table "live_ratings", id: :integer, charset: "latin1", force: :cascade do |t|
+    t.integer "icu_id"
+    t.integer "rating", limit: 2
+    t.integer "games", limit: 2
+    t.boolean "full", default: false
+    t.integer "last_rating", limit: 2
+    t.boolean "last_full", default: false
+    t.index ["icu_id"], name: "index_live_ratings_on_icu_id", unique: true
+  end
+
+  create_table "logins", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "ip", limit: 39
+    t.string "problem", limit: 8, default: "none"
+    t.string "role", limit: 20
+    t.datetime "created_at"
+  end
+
+  create_table "old_rating_histories", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "old_tournament_id"
+    t.integer "icu_player_id"
+    t.integer "old_rating", limit: 2
+    t.integer "new_rating", limit: 2
+    t.integer "performance_rating", limit: 2
+    t.integer "tournament_rating", limit: 2
+    t.integer "bonus", limit: 2
+    t.integer "games", limit: 1
+    t.integer "kfactor", limit: 1
+    t.decimal "actual_score", precision: 3, scale: 1
+    t.decimal "expected_score", precision: 8, scale: 6
+    t.index ["icu_player_id"], name: "index_old_rating_histories_on_icu_player_id"
+    t.index ["old_tournament_id", "icu_player_id"], name: "by_icu_player_old_tournament", unique: true
+    t.index ["old_tournament_id"], name: "index_old_rating_histories_on_old_tournament_id"
+  end
+
+  create_table "old_ratings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "icu_id"
+    t.integer "rating", limit: 2
+    t.integer "games", limit: 2
+    t.boolean "full", default: false
+    t.index ["icu_id"], name: "index_old_ratings_on_icu_id", unique: true
+  end
+
+  create_table "old_tournaments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.date "date"
     t.integer "player_count", limit: 2
   end
 
-  create_table "players", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "fed",                   limit: 3
-    t.string   "title",                 limit: 3
-    t.string   "gender",                limit: 1
-    t.integer  "icu_id"
-    t.integer  "fide_id"
-    t.integer  "icu_rating",            limit: 2
-    t.integer  "fide_rating",           limit: 2
-    t.date     "dob"
-    t.string   "status"
-    t.string   "category"
-    t.integer  "rank",                  limit: 2
-    t.integer  "num"
-    t.integer  "tournament_id"
-    t.string   "original_name"
-    t.string   "original_fed",          limit: 3
-    t.string   "original_title",        limit: 3
-    t.string   "original_gender",       limit: 1
-    t.integer  "original_icu_id"
-    t.integer  "original_fide_id"
-    t.integer  "original_icu_rating",   limit: 2
-    t.integer  "original_fide_rating",  limit: 2
-    t.date     "original_dob"
+  create_table "players", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "fed", limit: 3
+    t.string "title", limit: 3
+    t.string "gender", limit: 1
+    t.integer "icu_id"
+    t.integer "fide_id"
+    t.integer "icu_rating", limit: 2
+    t.integer "fide_rating", limit: 2
+    t.date "dob"
+    t.string "status"
+    t.string "category"
+    t.integer "rank", limit: 2
+    t.integer "num"
+    t.integer "tournament_id"
+    t.string "original_name"
+    t.string "original_fed", limit: 3
+    t.string "original_title", limit: 3
+    t.string "original_gender", limit: 1
+    t.integer "original_icu_id"
+    t.integer "original_fide_id"
+    t.integer "original_icu_rating", limit: 2
+    t.integer "original_fide_rating", limit: 2
+    t.date "original_dob"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "old_rating",            limit: 2
-    t.integer  "new_rating",            limit: 2
-    t.integer  "trn_rating",            limit: 2
-    t.integer  "old_games",             limit: 2
-    t.integer  "new_games",             limit: 2
-    t.integer  "bonus",                 limit: 2
-    t.integer  "k_factor",              limit: 1
-    t.integer  "last_player_id"
-    t.decimal  "actual_score",                    precision: 3, scale: 1
-    t.decimal  "expected_score",                  precision: 8, scale: 6
-    t.string   "last_signature"
-    t.string   "curr_signature"
-    t.boolean  "old_full",                                                default: false
-    t.boolean  "new_full",                                                default: false
-    t.boolean  "unrateable",                                              default: false
-    t.integer  "rating_change",         limit: 2,                         default: 0
-    t.integer  "pre_bonus_rating",      limit: 2
-    t.integer  "pre_bonus_performance", limit: 2
-    t.index ["fide_id"], name: "index_players_on_fide_id", using: :btree
-    t.index ["icu_id"], name: "index_players_on_icu_id", using: :btree
-    t.index ["rating_change"], name: "index_players_on_rating_change", using: :btree
-    t.index ["tournament_id"], name: "index_players_on_tournament_id", using: :btree
+    t.integer "old_rating", limit: 2
+    t.integer "new_rating", limit: 2
+    t.integer "trn_rating", limit: 2
+    t.integer "old_games", limit: 2
+    t.integer "new_games", limit: 2
+    t.integer "bonus", limit: 2
+    t.integer "k_factor", limit: 1
+    t.integer "last_player_id"
+    t.decimal "actual_score", precision: 3, scale: 1
+    t.decimal "expected_score", precision: 8, scale: 6
+    t.string "last_signature"
+    t.string "curr_signature"
+    t.boolean "old_full", default: false
+    t.boolean "new_full", default: false
+    t.boolean "unrateable", default: false
+    t.integer "rating_change", limit: 2, default: 0
+    t.integer "pre_bonus_rating", limit: 2
+    t.integer "pre_bonus_performance", limit: 2
+    t.index ["fide_id"], name: "index_players_on_fide_id"
+    t.index ["icu_id"], name: "index_players_on_icu_id"
+    t.index ["rating_change"], name: "index_players_on_rating_change"
+    t.index ["tournament_id"], name: "index_players_on_tournament_id"
   end
 
-  create_table "publications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "rating_list_id"
-    t.integer  "last_tournament_id"
-    t.text     "report",             limit: 65535
+  create_table "publications", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "rating_list_id"
+    t.integer "last_tournament_id"
+    t.text "report"
     t.datetime "created_at"
-    t.integer  "total",              limit: 3
-    t.integer  "creates",            limit: 3
-    t.integer  "remains",            limit: 3
-    t.integer  "updates",            limit: 3
-    t.integer  "deletes",            limit: 3
-    t.text     "notes",              limit: 65535
-    t.index ["rating_list_id"], name: "index_publications_on_rating_list_id", using: :btree
+    t.integer "total", limit: 3
+    t.integer "creates", limit: 3
+    t.integer "remains", limit: 3
+    t.integer "updates", limit: 3
+    t.integer "deletes", limit: 3
+    t.text "notes"
+    t.index ["rating_list_id"], name: "index_publications_on_rating_list_id"
   end
 
-  create_table "rating_lists", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.date     "date"
-    t.date     "tournament_cut_off"
+  create_table "rating_lists", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.date "date"
+    t.date "tournament_cut_off"
     t.datetime "created_at"
-    t.date     "payment_cut_off"
-    t.index ["date"], name: "index_rating_lists_on_date", using: :btree
+    t.date "payment_cut_off"
+    t.index ["date"], name: "index_rating_lists_on_date"
   end
 
-  create_table "rating_runs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "user_id"
-    t.string   "status"
-    t.text     "report",                  limit: 65535
-    t.integer  "start_tournament_id"
-    t.integer  "last_tournament_id"
-    t.integer  "start_tournament_rorder"
-    t.integer  "last_tournament_rorder"
-    t.string   "start_tournament_name"
-    t.string   "last_tournament_name"
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
-    t.string   "reason",                  limit: 100,   default: "", null: false
+  create_table "rating_runs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "status"
+    t.text "report"
+    t.integer "start_tournament_id"
+    t.integer "last_tournament_id"
+    t.integer "start_tournament_rorder"
+    t.integer "last_tournament_rorder"
+    t.string "start_tournament_name"
+    t.string "last_tournament_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "reason", limit: 100, default: "", null: false
   end
 
-  create_table "results", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "round",          limit: 1
-    t.integer  "player_id"
-    t.integer  "opponent_id"
-    t.string   "result",         limit: 1
-    t.string   "colour",         limit: 1
-    t.boolean  "rateable"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.decimal  "expected_score",           precision: 8, scale: 6
-    t.decimal  "rating_change",            precision: 8, scale: 6
-    t.index ["opponent_id"], name: "index_results_on_opponent_id", using: :btree
-    t.index ["player_id"], name: "index_results_on_player_id", using: :btree
-    t.index ["rating_change"], name: "index_results_on_rating_change", using: :btree
-  end
-
-  create_table "subscriptions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "icu_id"
-    t.string   "season",     limit: 7
-    t.string   "category",   limit: 8
-    t.date     "pay_date"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
-    t.index ["category"], name: "index_subscriptions_on_category", using: :btree
-    t.index ["icu_id"], name: "index_subscriptions_on_icu_id", using: :btree
-    t.index ["season"], name: "index_subscriptions_on_season", using: :btree
-  end
-
-  create_table "tournaments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "city"
-    t.string   "site"
-    t.string   "arbiter"
-    t.string   "deputy"
-    t.string   "tie_breaks"
-    t.string   "time_control"
-    t.date     "start"
-    t.date     "finish"
-    t.string   "fed",                    limit: 3
-    t.integer  "rounds",                 limit: 1
-    t.integer  "user_id"
-    t.string   "original_name"
-    t.string   "original_tie_breaks"
-    t.date     "original_start"
-    t.date     "original_finish"
+  create_table "results", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "round", limit: 1
+    t.integer "player_id"
+    t.integer "opponent_id"
+    t.string "result", limit: 1
+    t.string "colour", limit: 1
+    t.boolean "rateable"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "status",                               default: "ok"
-    t.string   "stage",                  limit: 20,    default: "initial"
-    t.integer  "rorder"
-    t.integer  "reratings",              limit: 2,     default: 0
-    t.integer  "next_tournament_id"
-    t.integer  "last_tournament_id"
-    t.integer  "old_last_tournament_id"
+    t.decimal "expected_score", precision: 8, scale: 6
+    t.decimal "rating_change", precision: 8, scale: 6
+    t.index ["opponent_id"], name: "index_results_on_opponent_id"
+    t.index ["player_id"], name: "index_results_on_player_id"
+    t.index ["rating_change"], name: "index_results_on_rating_change"
+  end
+
+  create_table "subscriptions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.integer "icu_id"
+    t.string "season", limit: 7
+    t.string "category", limit: 8
+    t.date "pay_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_subscriptions_on_category"
+    t.index ["icu_id"], name: "index_subscriptions_on_icu_id"
+    t.index ["season"], name: "index_subscriptions_on_season"
+  end
+
+  create_table "tournaments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.string "city"
+    t.string "site"
+    t.string "arbiter"
+    t.string "deputy"
+    t.string "tie_breaks"
+    t.string "time_control"
+    t.date "start"
+    t.date "finish"
+    t.string "fed", limit: 3
+    t.integer "rounds", limit: 1
+    t.integer "user_id"
+    t.string "original_name"
+    t.string "original_tie_breaks"
+    t.date "original_start"
+    t.date "original_finish"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "status", default: "ok"
+    t.string "stage", limit: 20, default: "initial"
+    t.integer "rorder"
+    t.integer "reratings", limit: 2, default: 0
+    t.integer "next_tournament_id"
+    t.integer "last_tournament_id"
+    t.integer "old_last_tournament_id"
     t.datetime "first_rated"
-    t.integer  "first_rated_msec",       limit: 2,     default: 0
+    t.integer "first_rated_msec", limit: 2
     t.datetime "last_rated"
-    t.integer  "last_rated_msec",        limit: 2
-    t.string   "last_signature",         limit: 32
-    t.string   "curr_signature",         limit: 32
-    t.boolean  "locked",                               default: false
-    t.text     "notes",                  limit: 65535
-    t.integer  "fide_id"
-    t.integer  "iterations1",            limit: 2,     default: 0
-    t.integer  "iterations2",            limit: 2,     default: 0
-    t.boolean  "rerate",                               default: false
-    t.index ["curr_signature"], name: "index_tournaments_on_curr_signature", using: :btree
-    t.index ["last_rated"], name: "index_tournaments_on_last_rated", using: :btree
-    t.index ["last_rated_msec"], name: "index_tournaments_on_last_rated_msec", using: :btree
-    t.index ["last_signature"], name: "index_tournaments_on_last_signature", using: :btree
-    t.index ["last_tournament_id"], name: "index_tournaments_on_last_tournament_id", using: :btree
-    t.index ["old_last_tournament_id"], name: "index_tournaments_on_old_last_tournament_id", using: :btree
-    t.index ["rorder"], name: "index_tournaments_on_rorder", unique: true, using: :btree
-    t.index ["stage"], name: "index_tournaments_on_stage", using: :btree
-    t.index ["user_id"], name: "index_tournaments_on_user_id", using: :btree
+    t.integer "last_rated_msec", limit: 2
+    t.string "last_signature", limit: 32
+    t.string "curr_signature", limit: 32
+    t.boolean "locked", default: false
+    t.text "notes"
+    t.integer "fide_id"
+    t.integer "iterations1", limit: 2, default: 0
+    t.integer "iterations2", limit: 2, default: 0
+    t.boolean "rerate", default: false
+    t.index ["curr_signature"], name: "index_tournaments_on_curr_signature"
+    t.index ["last_rated"], name: "index_tournaments_on_last_rated"
+    t.index ["last_rated_msec"], name: "index_tournaments_on_last_rated_msec"
+    t.index ["last_signature"], name: "index_tournaments_on_last_signature"
+    t.index ["last_tournament_id"], name: "index_tournaments_on_last_tournament_id"
+    t.index ["old_last_tournament_id"], name: "index_tournaments_on_old_last_tournament_id"
+    t.index ["rorder"], name: "index_tournaments_on_rorder", unique: true
+    t.index ["stage"], name: "index_tournaments_on_stage"
+    t.index ["user_id"], name: "index_tournaments_on_user_id"
   end
 
-  create_table "uploads", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name"
-    t.string   "format"
-    t.string   "content_type"
-    t.string   "file_type"
-    t.integer  "size"
-    t.integer  "tournament_id"
-    t.integer  "user_id"
-    t.text     "error",         limit: 65535
+  create_table "uploads", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.string "format"
+    t.string "content_type"
+    t.string "file_type"
+    t.integer "size"
+    t.integer "tournament_id"
+    t.integer "user_id"
+    t.text "error"
     t.datetime "created_at"
-    t.index ["tournament_id"], name: "index_uploads_on_tournament_id", using: :btree
-    t.index ["user_id"], name: "index_uploads_on_user_id", using: :btree
+    t.index ["tournament_id"], name: "index_uploads_on_tournament_id"
+    t.index ["user_id"], name: "index_uploads_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "email",           limit: 50
-    t.string   "preferred_email", limit: 50
-    t.string   "password",        limit: 32
-    t.string   "role",            limit: 20, default: "member"
-    t.integer  "icu_id"
-    t.date     "expiry"
+  create_table "users", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "email", limit: 50
+    t.string "preferred_email", limit: 50
+    t.string "password", limit: 32
+    t.string "role", limit: 20, default: "member"
+    t.integer "icu_id"
+    t.date "expiry"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "salt",            limit: 32
-    t.string   "status",          limit: 20, default: "ok"
+    t.string "salt", limit: 32
+    t.string "status", limit: 20, default: "ok"
     t.datetime "last_pulled_at"
-    t.string   "last_pull"
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.string "last_pull"
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/lib/fide/download.rb
+++ b/lib/fide/download.rb
@@ -335,13 +335,14 @@ module FIDE
 
     def get_download_details
       res = request("https://ratings.fide.com/download_lists.phtml")
-      # Example HTML that must be parsed
-      # <a href=https://ratings.fide.com/download/standard_rating_list_xml.zip class=tur>XML format</a>
-      # <small>(23 Apr 2026, Sz: 13.17 MB)</small>
-      raise SyncError.new("no links detected") unless res.body.match(/href=["']?(https?:\/\/ratings\.fide\.com\/download\/standard_rating_list_xml\.zip)[^>]*>[^<]+<\/a>[^<]*<small>([^<,]+, [^<]+)<\/small>/)
+      # Example HTML that must be parsed for the combined ratings list link
+      # <a href=https://ratings.fide.com/download/players_list_xml.zip class=tur>XML format</a>
+      # <small>(02 May 2026, Sz: 45.85 MB)</small>
+      raise SyncError.new("no links detected") unless res.body.match(/href=["']?(https?:\/\/ratings\.fide\.com\/download\/players_list_xml\.zip)[^>]*>[^<]+<\/a>[^<]*<small>([^<,]+, [^<]+)<\/small>/)
       @link = $1
       note = $2
-      @file = "standard_rating_list.xml"
+      # The file name that is inside the zip file
+      @file = "players_list_xml_foa.xml"
       raise SyncError.new("no updated date found in note") unless note.match(/\((\d[\d\w\s]+\d)\s*,/i)
       updated = Date.parse($1)
       raise SyncError.new("no file size found in note") unless note.match(/Sz:\s+(\d[\d\.]+\d)\s+MB/i)
@@ -393,7 +394,7 @@ module FIDE
     end
 
     class Player
-      attr_reader :id, :first_name, :last_name, :fed, :born, :gender, :title, :rating, :games, :active
+      attr_reader :id, :first_name, :last_name, :fed, :born, :gender, :title, :rating, :games, :active, :rapid_rating, :blitz_rating
       NULL = '\N'
 
       def initialize(hash)
@@ -404,6 +405,8 @@ module FIDE
         self.gender = hash["sex"]      if hash["sex"]
         self.title  = hash["title"]    if hash["title"]
         self.rating = hash["rating"]   if hash["rating"]
+        self.rapid_rating = hash["rapid_rating"] if hash["rapid_rating"]
+        self.blitz_rating = hash["blitz_rating"] if hash["blitz_rating"]
         self.games  = hash["games"]    if hash["games"]
         self.active = hash["flag"]
         self.gender ||= 'M' # The special rule for when FIDE players don't have a gender. Only need it for one player.
@@ -447,6 +450,16 @@ module FIDE
         @rating = nil if @rating == 0
       end
 
+      def rapid_rating=(rating)
+        @rapid_rating = rating.to_i
+        @rapid_rating = nil if @rapid_rating == 0
+      end
+
+      def blitz_rating=(rating)
+        @blitz_rating = rating.to_i
+        @blitz_rating = nil if @blitz_rating == 0
+      end
+
       def games=(games)
         @games = games.to_i
       end
@@ -464,11 +477,11 @@ module FIDE
       end
 
       def to_s
-        "#{id}|#{first_name}|#{last_name}|#{fed}|#{born}|#{gender}|#{title}|#{rating}|#{games}|#{active}"
+        "#{id}|#{first_name}|#{last_name}|#{fed}|#{born}|#{gender}|#{title}|#{rating}|#{rapid_rating}|#{blitz_rating}|#{games}|#{active}"
       end
 
       def to_h
-        [:id, :first_name, :last_name, :fed, :born, :gender, :title, :rating, :games, :active].inject({}){ |m, a| m[a] = send(a); m }
+        [:id, :first_name, :last_name, :fed, :born, :gender, :title, :rating, :rapid_rating, :blitz_rating, :games, :active].inject({}){ |m, a| m[a] = send(a); m }
       end
 
       # This is used to create a CSV file to load into MySQL and must match the fide_players columns in order.
@@ -485,6 +498,8 @@ module FIDE
         csv.push NULL # ICU ID
         csv.push created_at
         csv.push updated_at
+        csv.push rapid_rating ? rapid_rating.to_s : NULL
+        csv.push blitz_rating ? blitz_rating.to_s : NULL
         csv.join(",")
       end
     end
@@ -494,7 +509,7 @@ module FIDE
 
       def initialize(&block)
         @block = block
-        @attrs = Regexp.new("^(fideid|name|country|sex|title|rating|games|birthday|flag)$")
+        @attrs = Regexp.new("^(fideid|name|country|sex|title|rating|rapid_rating|blitz_rating|games|birthday|flag)$")
         @state = ""
       end
 

--- a/spec/other/fide_download_spec.rb
+++ b/spec/other/fide_download_spec.rb
@@ -32,6 +32,8 @@ module FIDE
         expect(me.gender).to eq("M")
         expect(me.born).to eq(1955)
         expect(me.rating).to eq(2240)
+        expect(me.rapid_rating).to be_nil
+        expect(me.blitz_rating).to be_nil
         expect(me.games).to eq(0)
         expect(me.title).to eq("IM")
         expect(me.fed).to eq("IRL")
@@ -43,6 +45,8 @@ module FIDE
         expect(april.gender).to eq("F")
         expect(april.born).to eq(1960)
         expect(april.rating).to eq(2055)
+        expect(april.rapid_rating).to be_nil
+        expect(april.blitz_rating).to be_nil
         expect(april.games).to eq(0)
         expect(april.title).to be_nil
         expect(april.fed).to eq("IRL")
@@ -54,6 +58,8 @@ module FIDE
         expect(gearoidin.gender).to eq("F")
         expect(gearoidin.born).to eq(1964)
         expect(gearoidin.rating).to eq(1894)
+        expect(gearoidin.rapid_rating).to be_nil
+        expect(gearoidin.blitz_rating).to be_nil
         expect(gearoidin.games).to eq(0)
         expect(gearoidin.title).to eq("WCM")
         expect(gearoidin.fed).to eq("IRL")
@@ -65,6 +71,8 @@ module FIDE
         expect(mark.gender).to eq("M")
         expect(mark.born).to eq(1976)
         expect(mark.rating).to eq(2388)
+        expect(mark.rapid_rating).to be_nil
+        expect(mark.blitz_rating).to be_nil
         expect(mark.games).to eq(0)
         expect(mark.title).to eq("IM")
         expect(mark.fed).to eq("IRL")
@@ -76,6 +84,8 @@ module FIDE
         expect(bernard.gender).to eq("M")
         expect(bernard.born).to eq(1955)
         expect(bernard.rating).to eq(2380)
+        expect(bernard.rapid_rating).to be_nil
+        expect(bernard.blitz_rating).to be_nil
         expect(bernard.games).to eq(0)
         expect(bernard.title).to be_nil
         expect(bernard.fed).to eq("IRL")
@@ -87,6 +97,8 @@ module FIDE
         expect(debbie.gender).to eq("F")
         expect(debbie.born).to eq(1969)
         expect(debbie.rating).to eq(1841)
+        expect(debbie.rapid_rating).to be_nil
+        expect(debbie.blitz_rating).to be_nil
         expect(debbie.games).to eq(0)
         expect(debbie.title).to be_nil
         expect(debbie.fed).to eq("IRL")
@@ -112,6 +124,8 @@ module FIDE
         expect(magnus.gender).to eq("M")
         expect(magnus.born).to eq(1990)
         expect(magnus.rating).to eq(2843)
+        expect(magnus.rapid_rating).to eq(2845)
+        expect(magnus.blitz_rating).to eq(2856)
         expect(magnus.games).to eq(10)
         expect(magnus.title).to eq("GM")
         expect(magnus.fed).to eq("NOR")
@@ -123,6 +137,8 @@ module FIDE
         expect(shakri.gender).to eq("M")
         expect(shakri.born).to eq(1985)
         expect(shakri.rating).to eq(2729)
+        expect(shakri.rapid_rating).to eq(2760)
+        expect(shakri.blitz_rating).to eq(2701)
         expect(shakri.games).to eq(0)
         expect(shakri.title).to eq("GM")
         expect(shakri.fed).to eq("AZE")
@@ -134,6 +150,8 @@ module FIDE
         expect(sofia.gender).to eq("F")
         expect(sofia.born).to be nil
         expect(sofia.rating).to eq(2080)
+        expect(sofia.rapid_rating).to be_nil
+        expect(sofia.blitz_rating).to be_nil
         expect(sofia.games).to eq(0)
         expect(sofia.title).to be_nil
         expect(sofia.fed).to eq("RUS")
@@ -144,7 +162,7 @@ module FIDE
     context "updating FIDE players" do
       before(:each) do
         @mark = FidePlayer.create!(first_name: "Mark", last_name: "Quinn", fed: "IRL", gender: "M", id: 2500450, rating: 2422, icu_id: 1402)
-        @shak = FidePlayer.create!(first_name: "Shakhriyar", last_name: "Mamedyarov", fed: "AZE",  gender: "M", id: 13401319, rating: 2700)
+        @shak = FidePlayer.create!(first_name: "Shakhriyar", last_name: "Mamedyarov", fed: "AZE",  gender: "M", id: 13401319, rating: 2700, rapid_rating: 2700, blitz_rating: 2700)
         @sofia = FidePlayer.create!(first_name: "Sofia", last_name: "Zyzlova", fed: "RUS", gender: "F", id: 24150797, icu_id: 2222)
 
         @download = FIDE::Download.new
@@ -166,6 +184,8 @@ module FIDE
       it "should update player rating" do
         expect(@mark.rating).to eq(2388)
         expect(@shak.rating).to eq(2729)
+        expect(@shak.rapid_rating).to eq(2760)
+        expect(@shak.blitz_rating).to eq(2701)
         expect(@sofia.rating).to eq(2080)
       end
 


### PR DESCRIPTION
Resolves #44.

The download list link was changed so that it includes the rapid and blitz ratings. Extra fields were added to store these ratings. Historical rating data for rapid and blitz ratings, similar to what the `FideRating` table does for standard ratings was _not_ implemented.