### PR TITLE
Added a 'Top Irish Women' page

### DIFF
--- a/app/controllers/icu_ratings_controller.rb
+++ b/app/controllers/icu_ratings_controller.rb
@@ -43,6 +43,11 @@ class IcuRatingsController < ApplicationController
     render "icu_ratings/seniors/#{ request.xhr? ? 'results' : 'index' }"
   end
 
+  def women
+    @women = IcuRatings::Women.new(params)
+    render "icu_ratings/women/#{ request.xhr? ? 'results' : 'index' }"
+  end
+
   def improvers
     @improvers = IcuRatings::Improvers.new(params)
     render "icu_ratings/improvers/#{ request.xhr? ? 'results' : 'index' }"

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,7 @@ class Ability
     can :war, IcuRating
     can :juniors, IcuRating
     can :seniors, IcuRating
+    can :women, IcuRating
     can :improvers, IcuRating
     can :show, IcuRating
     can :graph, IcuPlayer

--- a/app/presenters/icu_ratings/women.rb
+++ b/app/presenters/icu_ratings/women.rb
@@ -1,0 +1,28 @@
+module IcuRatings
+  class Women
+    attr_reader :list, :club
+
+    def initialize(params)
+      @club = params[:club]
+      @list = params[:list]
+    end
+
+    def list
+      @list ||= IcuRating.unscoped.maximum(:list)
+    end
+
+    def ratings
+      return @ratings if @ratings
+      return [] unless available?
+      @ratings = IcuRating.unscoped.order("rating DESC").includes(:icu_player).references(:icu_player)
+      @ratings = @ratings.where(list: list).where("icu_players.fed = 'IRL' OR icu_players.fed IS NULL")
+      @ratings = @ratings.where("icu_players.gender = 'F'") # Filters for women
+      @ratings = @ratings.where("icu_players.club = ?", @club) if @club.present?
+      @ratings
+    end
+
+    def available?
+      list ? true : false
+    end
+  end
+end

--- a/app/views/icu_ratings/women/_form.html.haml
+++ b/app/views/icu_ratings/women/_form.html.haml
@@ -1,0 +1,10 @@
+= form_tag women_icu_ratings_path, method: "get", id: handle_remote_id do
+  %table{class: "invisible"}
+    %tr
+      %th= label_tag :list, "List"
+      %th= label_tag :club
+      %th
+    %tr
+      %td= select_tag :list, options_for_select(icu_rating_list_menu("Any"), params[:list]), onchange: handle_remote
+      %td= select_tag :club, options_for_select(club_menu(nil), params[:club]), onchange: handle_remote
+      %td= submit_tag "Search"

--- a/app/views/icu_ratings/women/_results.html.haml
+++ b/app/views/icu_ratings/women/_results.html.haml
@@ -1,0 +1,16 @@
+%table
+  %tr
+    %th
+    %th Player
+    %th Club
+    %th Rating
+  - @women.ratings.each_with_index do |r, i|
+    - p = r.icu_player
+    %tr
+      %td{class: "centered"}= i + 1
+      %td= p.name
+      %td= p.club
+      %td{class: "#{r.type}"}= link_to r.rating, icu_rating_path(r, format: "js"), remote: true
+  - if @women.ratings.size == 0
+    %tr
+      %td{class: "centered", colspan: 6} No matches

--- a/app/views/icu_ratings/women/index.html.haml
+++ b/app/views/icu_ratings/women/index.html.haml
@@ -1,0 +1,23 @@
+.header
+  %span= @page_title = "Top Irish Women"
+
+#women_form_div
+  = render "icu_ratings/women/form"
+
+#women_results.turbaned
+  = render "icu_ratings/women/results"
+
+= render "shared/ratings_graph/dialog"
+
+#help
+  %dl
+    %dt What players are included in this list?
+    %dd
+      %p Those who satisfy the following criteria:
+      %ul
+        %li federation is not foreign,
+        %li are female,
+        - if @women.available?
+          %li
+            appeared in the selected rating list.
+    = render partial: "shared/search_form_help"

--- a/app/views/icu_ratings/women/results.js.erb
+++ b/app/views/icu_ratings/women/results.js.erb
@@ -1,0 +1,1 @@
+$("#women_results").html("<%= j render('icu_ratings/women/results') %>");

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -41,6 +41,8 @@
         %li= link_to "Top Juniors", juniors_icu_ratings_path
       - if can?(:juniors, IcuRating)
         %li= link_to "Top Seniors", seniors_icu_ratings_path
+      - if can?(:women, IcuRating)
+        %li= link_to "Top Women", women_icu_ratings_path
       - if can?(:juniors, IcuRating)
         %li= link_to "Top Improvers", improvers_icu_ratings_path
       - if can?(:juniors, IcuRating)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Ratings::Application.routes.draw do
     get :graph, on: :member
   end
   resources :icu_ratings,  only: [:index, :show] do
-    get :war, :juniors, :seniors, :improvers, on: :collection
+    get :war, :juniors, :seniors, :women, :improvers, on: :collection
   end
   resources :live_ratings, only: [:index]
   resources :players,      only: [:show]

--- a/spec/presenters/icu_ratings/women_spec.rb
+++ b/spec/presenters/icu_ratings/women_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+module IcuRatings
+  describe Women do
+    describe "insufficient data" do
+      it "should be unavailable" do
+        w = Women.new({})
+        expect(w.available?).to be false
+        expect(w.ratings).to be_empty
+      end
+    end
+
+    describe "enough data" do
+      before(:each) do
+        @list = "2011-09-01"
+        @p1 = FactoryBot.create(:icu_player, gender: "F")
+        @p2 = FactoryBot.create(:icu_player, gender: "F", club: "Bray")
+        @p3 = FactoryBot.create(:icu_player, gender: "M")
+        @p4 = FactoryBot.create(:icu_player, gender: "F", fed: "ENG")
+        @p5 = FactoryBot.create(:icu_player, gender: nil)
+        @r1 = FactoryBot.create(:icu_rating, list: @list, icu_player: @p1, rating: 1500)
+        @r2 = FactoryBot.create(:icu_rating, list: @list, icu_player: @p2, rating: 1800)
+        @r3 = FactoryBot.create(:icu_rating, list: @list, icu_player: @p3, rating: 2000)
+        @r4 = FactoryBot.create(:icu_rating, list: @list, icu_player: @p4, rating: 1900)
+        @r5 = FactoryBot.create(:icu_rating, list: @list, icu_player: @p5, rating: 1700)
+        @r6 = FactoryBot.create(:icu_rating, list: "2011-05-01", icu_player: @p1, rating: 2100)
+      end
+
+      it "default settings" do
+        params = {}
+        w = Women.new(params)
+        expect(w.available?).to be true
+        expect(w.list.to_s).to eq(@list)
+        ratings = w.ratings
+        expect(ratings.size).to eq(2)
+        expect(ratings).to include(@r1)
+        expect(ratings).to include(@r2)
+      end
+
+      it "excludes men and players without a gender" do
+        ratings = Women.new({}).ratings
+        expect(ratings).not_to include(@r3)
+        expect(ratings).not_to include(@r5)
+      end
+
+      it "excludes ratings from a different list" do
+        ratings = Women.new({}).ratings
+        expect(ratings).not_to include(@r6)
+      end
+
+      it "excludes foreign federations" do
+        ratings = Women.new({}).ratings
+        expect(ratings).not_to include(@r4)
+      end
+
+      it "orders by rating descending" do
+        ratings = Women.new({}).ratings
+        expect(ratings.first).to eq(@r2)
+        expect(ratings.second).to eq(@r1)
+      end
+
+      it "filters by club" do
+        w = Women.new(club: "Bray")
+        ratings = w.ratings
+        expect(ratings.size).to eq(1)
+        expect(ratings).to include(@r2)
+      end
+
+      it "uses a given list instead of the latest one" do
+        w = Women.new(list: "2011-05-01")
+        ratings = w.ratings
+        expect(ratings.size).to eq(1)
+        expect(ratings).to include(@r6)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements #40, similarly to how the 'Top Irish Juniors' and 'Top Irish Seniors' routes are implemented.

Displays all female players in order of ICU rating. The results can be filtered by club and by rating list.